### PR TITLE
Replace boto strict version requirement with a greater than

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='mortar-luigi',
       install_requires=[
           'luigi',
           'requests',
-          'boto==2.24.0',
+          'boto>=2.24.0',
           'pymongo>=2.5',
           'mortar-api-python>=0.2.4'
       ],


### PR DESCRIPTION
`==` requirement is too strict, it can be incompatible with other applications requiring an other version of boto.
`>=` gives us the feature we need, without breaking the compatibility.